### PR TITLE
Add a build only CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    name: Release build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          # Read https://whichjdk.com/#tldr to understand the difference between different distributions
+          # MacOS might be running openjdk 17 (https://whichjdk.com/#apple-silicon) but we want to run the latest LTS on Linux
+          distribution: temurin
+          java-version: 21
+
+      # Generate AAR and POM files
+      - name: Release build
+        run: ./gradlew assembleRelease

--- a/connector/src/main/java/app/quiltt/connector/QuilttConnector.kt
+++ b/connector/src/main/java/app/quiltt/connector/QuilttConnector.kt
@@ -25,7 +25,7 @@ class QuilttConnector(context: Context) {
     }
 
     fun reconnect(
-        config: QuilttConnectorReconnectConfiguratio,
+        config: QuilttConnectorReconnectConfiguration,
         onEvent: ConnectorSDKOnEventCallback? = null,
         onExit: ConnectorSDKOnEventExitCallback? = null,
         onExitSuccess: ConnectorSDKOnExitSuccessCallback? = null,

--- a/connector/src/main/java/app/quiltt/connector/QuilttConnector.kt
+++ b/connector/src/main/java/app/quiltt/connector/QuilttConnector.kt
@@ -25,7 +25,7 @@ class QuilttConnector(context: Context) {
     }
 
     fun reconnect(
-        config: QuilttConnectorReconnectConfiguration,
+        config: QuilttConnectorReconnectConfiguratio,
         onEvent: ConnectorSDKOnEventCallback? = null,
         onExit: ConnectorSDKOnEventExitCallback? = null,
         onExitSuccess: ConnectorSDKOnExitSuccessCallback? = null,


### PR DESCRIPTION
Not ideal without testing the example app but at least we can detect some build error.

https://github.com/quiltt/quiltt-android/actions/runs/7572669098/job/20623039991
```bash
e: file:///home/runner/work/quiltt-android/quiltt-android/connector/src/main/java/app/quiltt/connector/QuilttConnector.kt:28:17 Unresolved reference: QuilttConnectorReconnectConfiguratio
```