### PR TITLE
Migrate from 'OAuthRequested' event to 'Navigate' event

### DIFF
--- a/connector/src/main/java/app/quiltt/connector/QuilttConnectorWebView.kt
+++ b/connector/src/main/java/app/quiltt/connector/QuilttConnectorWebView.kt
@@ -121,10 +121,28 @@ class QuilttConnectorWebViewClient(private val params: QuilttConnectorWebViewCli
             "Authenticate" -> {
                 println("Authenticate $profileId")
             }
-            "OauthRequested" -> {
-                val oauthUrlString = urlComponents.getQueryParameter("oauthUrl")
-                if (oauthUrlString != null && URLUtil.isHttpsUrl(oauthUrlString)) {
-                    handleOAuthUrl(Uri.parse(oauthUrlString))
+            "Navigate" -> {
+                val navigateUrlString = urlComponents.getQueryParameter("url")
+                if (navigateUrlString != null) {
+                    // Handle potential encoding issues
+                    if (UrlUtils.isEncoded(navigateUrlString)) {
+                        try {
+                            // If encoded, decode once to prevent double-encoding
+                            val decodedUrl = Uri.decode(navigateUrlString)
+                            if (URLUtil.isHttpsUrl(decodedUrl)) {
+                                handleOAuthUrl(Uri.parse(decodedUrl))
+                            }
+                        } catch (error: Exception) {
+                            println("Navigate URL decoding failed, using original")
+                            if (URLUtil.isHttpsUrl(navigateUrlString)) {
+                                handleOAuthUrl(Uri.parse(navigateUrlString))
+                            }
+                        }
+                    } else if (URLUtil.isHttpsUrl(navigateUrlString)) {
+                        handleOAuthUrl(Uri.parse(navigateUrlString))
+                    }
+                } else {
+                    println("Navigate URL missing from request")
                 }
             }
             else -> {


### PR DESCRIPTION
Waiting on https://github.com/quiltt/quiltt/pull/8488

<!--- CHANGELOG_START -->
## Improvements <!--- Delete section if not needed -->

- Migrate OAuth handling from using the `OAuthRequested` message to using `Navigate` message 

<!--- CHANGELOG_END -->

## Release Checklist

- [x] **Is commit history clean?**
  - Do all commit names start with verbs like `Add`, `Fix`, `Refactor`...?
  - Are all commits passing or marked with `[WIP]`?
- [x] **Are relevant documentation changes queued up?**
  - Are the Quiltt API Docs updated?
